### PR TITLE
feat: Add SPM test target for PropertyWrapper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,12 @@ let package = Package(
         .target(
             name: "TYPinchableImageView",
             path: "UILibraries/PinchableImageView/PinchableImageView/PinchableImageView/Classes"
+        ),
+        .testTarget(
+            name: "TYPropertyWrapperTests",
+            dependencies: ["TYPropertyWrapper"],
+            path: "Utils/PropertyWrapper/PropertyWrapperTests",
+            exclude: ["Info.plist"]
         )
     ]
 )

--- a/Utils/PropertyWrapper/PropertyWrapperTests/PropertyWrapperTests.swift
+++ b/Utils/PropertyWrapper/PropertyWrapperTests/PropertyWrapperTests.swift
@@ -7,7 +7,11 @@
 //
 
 import XCTest
+#if canImport(TYPropertyWrapper)
+@testable import TYPropertyWrapper
+#else
 @testable import PropertyWrapper
+#endif
 
 final class PropertyWrapperTests: XCTestCase {
     func test_AdminType_ShouldBeGivenTypeSelected() {


### PR DESCRIPTION
This PR adds a `.testTarget` for `TYPropertyWrapper` to `Package.swift`.
While the project contains tests for the `PropertyWrapper` component, they were not accessible or executable via Swift Package Manager (SPM).

### Changes
- Defined a `.testTarget` named `TYPropertyWrapperTests` in `Package.swift`.
- Updated the import statement in `PropertyWrapperTests.swift` using a conditional compilation block (`#if canImport`) to support both the Xcode target name (`PropertyWrapper`) and the SPM target name (`TYPropertyWrapper`).
- Excluded `Info.plist` from the test target to resolve SPM warnings.

This improvement allows developers to run tests directly from the terminal using `swift test` and paves the way for SPM-based CI/CD workflows.